### PR TITLE
Don't show lines when color is set to nil

### DIFF
--- a/Sources/TileView.swift
+++ b/Sources/TileView.swift
@@ -97,12 +97,15 @@ final class TileView: UIView {
     digitLabel.textColor       = builder.textColor
     digitLabel.backgroundColor = builder.backgroundColor
 
-    mainLineView.backgroundColor      = builder.lineColor
-    secondaryLineView.backgroundColor = builder.backgroundColor
-
     addSubview(digitLabel)
-    addSubview(mainLineView)
-    addSubview(secondaryLineView)
+    
+    // Don't add the line if the color was set to nil
+    if let lineColor = builder.lineColor {
+      mainLineView.backgroundColor      = lineColor
+      secondaryLineView.backgroundColor = builder.backgroundColor
+      addSubview(mainLineView)
+      addSubview(secondaryLineView)
+    }
   }
 
   // MARK: - Laying out Subviews


### PR DESCRIPTION
When a user sets the line color to "nil", don't display any lines.
The reason I did this is due to line removal.
I can set the line color to clear, then I only see one line. But if I set it to nil, I see two.  So I think the subviews shouldn't be added and it will remove those lines entirely.  There is a very very faint line, but almost looks gone.
Thanks, Mike